### PR TITLE
Add direction to `get_all` api calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ web-sys = { version = "0.3.55", features = [
     "DomStringList",
     "Event",
     "IdbCursorWithValue",
+	"IdbCursorDirection",
     "IdbDatabase",
     "IdbFactory",
     "IdbIndex",


### PR DESCRIPTION
This way you can obtain the records in reversed order.
That can be useful e.g. when you are storing events
and you want to display most recent events first.