### PR TITLE
Update docs versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To use Rexie, you need to add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rexie = "0.1"
+rexie = "0.2"
 ```
 
 ### Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! rexie = "0.1"
+//! rexie = "0.2"
 //! ```
 //!
 //! ## Example


### PR DESCRIPTION
The docs have the latest version listed as `0.1`, despite `0.2` having just been released. This just updates them in the README and in `lib.rs` (for docs.rs).