### PR TITLE
Clarify transaction committing docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rexie"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Devashish Dixit <devashishdxt@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Rexie is an easy-to-use, futures based wrapper around IndexedDB that compiles to webassembly"
@@ -52,7 +52,7 @@ wee_alloc = { version = "0.4.5", optional = true }
 
 [dev-dependencies]
 serde = { version = "1.0.133", features = ["derive"] }
-serde_json = "1.0.74"
+serde_json = "1.0.75"
 serde-wasm-bindgen = "0.4.1"
 wasm-bindgen-test = "0.3.28"
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To use Rexie, you need to add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rexie = "0.1"
+rexie = "0.2"
 ```
 
 ### Example

--- a/README.md
+++ b/README.md
@@ -94,9 +94,6 @@ async fn get_employee(rexie: &Rexie, id: u32) -> Result<Option<serde_json::Value
     // Convert it to `serde_json::Value` from `JsValue`
     let employee: Option<serde_json::Value> = serde_wasm_bindgen::from_value(employee).unwrap();
 
-    // Commit the transaction
-    transaction.commit().await?;
-
     // Return the employee
     Ok(employee)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! rexie = "0.1"
+//! rexie = "0.2"
 //! ```
 //!
 //! ## Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,9 +92,6 @@
 //!     // Convert it to `serde_json::Value` from `JsValue`
 //!     let employee: Option<serde_json::Value> = serde_wasm_bindgen::from_value(employee).unwrap();
 //!
-//!     // Commit the transaction
-//!     transaction.commit().await?;
-//!
 //!     // Return the employee
 //!     Ok(employee)
 //! }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -77,7 +77,7 @@ impl Transaction {
         wait_transaction_abort(self.idb_transaction).await
     }
 
-    /// Commits a transaction
+    /// Commits a transaction (this doesn't usually *have* to be called, see [MDN](https://developer.mozilla.org/en-US/docs/Web/API/IDBTransaction/commit))
     pub async fn commit(self) -> Result<()> {
         wait_request(self.idb_transaction, Error::TransactionExecutionFailed)
             .await


### PR DESCRIPTION
This just clarifies a few things regarding the need to run `Transaction.commit()` based on [this](https://developer.mozilla.org/en-US/docs/Web/API/IDBTransaction/commit) documentation on MDN. I've also removed the call to `.commit()` from the examples for getting data, because I don't think you need to commit for a read-only transaction (I could be wrong on this?).