### PR TITLE
Rethrow errors in the upgrade handler

### DIFF
--- a/src/rexie_builder.rs
+++ b/src/rexie_builder.rs
@@ -86,9 +86,9 @@ fn get_idb_open_request(name: &str, version: Option<u32>) -> Result<IdbOpenDbReq
 fn set_upgrade_handler(
     idb_open_request: &IdbOpenDbRequest,
     object_stores: Vec<ObjectStore>,
-) -> Closure<dyn FnMut(Event)> {
+) -> Closure<dyn FnMut(Event) -> std::result::Result<(), js_sys::Error>> {
     let upgrade_handler = Closure::once(move |event: Event| {
-        upgrade_handler(event, object_stores).unwrap_throw();
+        upgrade_handler(event, object_stores).map_err(|err| js_sys::Error::new(&format!("{err:?}")))
     });
 
     idb_open_request.set_onupgradeneeded(Some(upgrade_handler.as_ref().unchecked_ref()));


### PR DESCRIPTION
Currently, when there's something wrong with the configuration (like a compound primary key with autoincrement enabled, or invalid characters in the primary key), there's no error output other than `unwrap_throw`. With this change, the underlying error is propagated up, so it actually shows up in the web inspector console.

I've needed that quite a few times during development, so I figure it might be a good idea to include that for everybody.