### PR TITLE
Small API expansion & docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ wee_alloc = { version = "0.4.5", optional = true }
 [dev-dependencies]
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
-serde-wasm-bindgen = "0.4.3"
+serde-wasm-bindgen = "0.6"
 wasm-bindgen-test = "0.3.31"
 
 [profile.release]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,10 +88,10 @@
 //!     let employees = transaction.store("employees")?;
 //!     
 //!     // Get the employee
-//!     let employee = employees.get(&id.into()).await?;
-//!
-//!     // Convert it to `serde_json::Value` from `JsValue`
-//!     let employee: Option<serde_json::Value> = serde_wasm_bindgen::from_value(employee).unwrap();
+//!     let employee = employees.get(&id.into())
+//!                        .await?
+//!                         // Convert it to `serde_json::Value` from `JsValue`
+//!                        .map(|employee| serde_wasm_bindgen::from_value(employee).unwrap());
 //!
 //!     // Return the employee
 //!     Ok(employee)

--- a/src/rexie_builder.rs
+++ b/src/rexie_builder.rs
@@ -103,8 +103,11 @@ fn upgrade_handler(event: Event, object_stores: Vec<ObjectStore>) -> Result<()> 
         .map_err(Error::IndexedDbNotSupported)?
         .unchecked_into();
 
+    let pre_migration_db_store_names = idb.object_store_names();
     for object_store in object_stores {
-        object_store.create(&idb_open_request, &idb)?;
+        if !pre_migration_db_store_names.contains(&object_store.name) {
+            object_store.create(&idb_open_request, &idb)?;
+        }
     }
 
     let db_store_names = idb.object_store_names();

--- a/src/transaction/index.rs
+++ b/src/transaction/index.rs
@@ -42,6 +42,19 @@ impl StoreIndex {
         wait_request(request, Error::IndexedDbRequestError).await
     }
 
+    /// retrieves the primary keys of all objects inside the index
+    /// See: [MDN:IDBIndex/getAllKeys](https://developer.mozilla.org/en-US/docs/Web/API/IDBIndex/getAllKeys)
+    pub async fn all_keys(&self, key_range: Option<&KeyRange>, limit: Option<u32>) -> Result<JsValue> {
+        let request = match (key_range, limit) {
+            (None, None) => self.idb_index.get_all_keys(),
+            (None, Some(limit)) => self.idb_index.get_all_keys_with_key_and_limit(&JsValue::UNDEFINED, limit),
+            (Some(key_range), None) => self.idb_index.get_all_keys_with_key(key_range.as_ref()),
+            (Some(key_range), Some(limit)) => self.idb_index.get_all_keys_with_key_and_limit(key_range.as_ref(), limit),
+        }.map_err(Error::IndexedDbRequestError)?;
+
+        wait_request(request, Error::IndexedDbRequestError).await
+    }
+
     /// Gets all key-value pairs from the store with given key range, limit, offset and direction
     pub async fn get_all(
         &self,

--- a/src/transaction/index.rs
+++ b/src/transaction/index.rs
@@ -33,24 +33,38 @@ impl StoreIndex {
     }
 
     /// Gets a value from the store with given key
-    pub async fn get(&self, key: &JsValue) -> Result<JsValue> {
+    pub async fn get(&self, key: &JsValue) -> Result<Option<JsValue>> {
         let request = self
             .idb_index
             .get(key)
             .map_err(Error::IndexedDbRequestError)?;
 
-        wait_request(request, Error::IndexedDbRequestError).await
+        let response = wait_request(request, Error::IndexedDbRequestError).await?;
+        if response.is_undefined() || response.is_null() {
+            Ok(None)
+        } else {
+            Ok(Some(response))
+        }
     }
 
     /// retrieves the primary keys of all objects inside the index
     /// See: [MDN:IDBIndex/getAllKeys](https://developer.mozilla.org/en-US/docs/Web/API/IDBIndex/getAllKeys)
-    pub async fn all_keys(&self, key_range: Option<&KeyRange>, limit: Option<u32>) -> Result<JsValue> {
+    pub async fn all_keys(
+        &self,
+        key_range: Option<&KeyRange>,
+        limit: Option<u32>,
+    ) -> Result<JsValue> {
         let request = match (key_range, limit) {
             (None, None) => self.idb_index.get_all_keys(),
-            (None, Some(limit)) => self.idb_index.get_all_keys_with_key_and_limit(&JsValue::UNDEFINED, limit),
+            (None, Some(limit)) => self
+                .idb_index
+                .get_all_keys_with_key_and_limit(&JsValue::UNDEFINED, limit),
             (Some(key_range), None) => self.idb_index.get_all_keys_with_key(key_range.as_ref()),
-            (Some(key_range), Some(limit)) => self.idb_index.get_all_keys_with_key_and_limit(key_range.as_ref(), limit),
-        }.map_err(Error::IndexedDbRequestError)?;
+            (Some(key_range), Some(limit)) => self
+                .idb_index
+                .get_all_keys_with_key_and_limit(key_range.as_ref(), limit),
+        }
+        .map_err(Error::IndexedDbRequestError)?;
 
         wait_request(request, Error::IndexedDbRequestError).await
     }

--- a/src/transaction/store.rs
+++ b/src/transaction/store.rs
@@ -17,17 +17,20 @@ impl Store {
         Self { idb_store }
     }
 
-    /// Returns weather the store has auto increment enabled
+    /// Returns whether the store has auto increment enabled
+    /// MDN Reference: [IDBObjectStore.autoIncrement](https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/autoIncrement)
     pub fn auto_increment(&self) -> bool {
         self.idb_store.auto_increment()
     }
 
     /// Returns the name of the store
+    /// MDN Reference: [IDBObjectStore.name](https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/name)
     pub fn name(&self) -> String {
         self.idb_store.name()
     }
 
     /// Returns the key path of the store
+    /// MDN Reference: [IDBObjectStore.keyPath](https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/keyPath)
     pub fn key_path(&self) -> Result<Option<String>> {
         self.idb_store
             .key_path()
@@ -36,12 +39,13 @@ impl Store {
     }
 
     /// Returns all the index names of the store
+    /// MDN Reference: [IDBObjectStore/indexNames](https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/indexNames)
     pub fn index_names(&self) -> Vec<String> {
         let list = self.idb_store.index_names();
+        let list_len = list.length();
+        let mut result = Vec::with_capacity(list_len as usize);
 
-        let mut result = Vec::new();
-
-        for index in 0..list.length() {
+        for index in 0..list_len {
             if let Some(s) = list.get(index) {
                 result.push(s);
             }
@@ -51,6 +55,7 @@ impl Store {
     }
 
     /// Returns index of the store with given name
+    /// MDN Reference: [IDBObjectStore/index](https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/index)
     pub fn index(&self, name: &str) -> Result<StoreIndex> {
         let idb_index = self.idb_store.index(name).map_err(Error::IndexOpenFailed)?;
 
@@ -58,11 +63,34 @@ impl Store {
     }
 
     /// Gets a value from the store with given key
+    /// MDN Reference: [IDBObjectStore/get](https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/get)
     pub async fn get(&self, key: &JsValue) -> Result<JsValue> {
         let request = self
             .idb_store
             .get(key)
             .map_err(Error::IndexedDbRequestError)?;
+
+        wait_request(request, Error::IndexedDbRequestError).await
+    }
+
+    /// Checks if a given key exists within the store
+    /// MDN Reference: [IDBObjectStore/getKey](https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/getKey)
+    pub async fn key_exists(&self, key: &JsValue) -> Result<bool> {
+        let request = self.idb_store.get_key(key).map_err(Error::IndexedDbRequestError)?;
+        let result = wait_request(request, Error::IndexedDbRequestError).await?;
+        Ok(result.as_bool().unwrap_or_default())
+    }
+
+    /// Retrieves record keys for all objects in the object store matching the specified
+    /// parameter or all objects in the store if no parameters are given.
+    /// MDN Reference: [IDBStore/getAllKeys](https://developer.mozilla.org/en-US/docs/Web/API/IDBStore/getAllKeys)
+    pub async fn all_keys(&self, key_range: Option<&KeyRange>, limit: Option<u32>) -> Result<JsValue> {
+        let request = match (key_range, limit) {
+            (None, None) => self.idb_store.get_all_keys(),
+            (None, Some(limit)) => self.idb_store.get_all_keys_with_key_and_limit(&JsValue::UNDEFINED, limit),
+            (Some(key_range), None) => self.idb_store.get_all_keys_with_key(key_range.as_ref()),
+            (Some(key_range), Some(limit)) => self.idb_store.get_all_keys_with_key_and_limit(key_range.as_ref(), limit),
+        }.map_err(Error::IndexedDbRequestError)?;
 
         wait_request(request, Error::IndexedDbRequestError).await
     }

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -135,10 +135,10 @@ async fn get_employee(rexie: &Rexie, id: u32) -> Result<Option<Employee>> {
     assert!(employees.is_ok());
     let employees = employees.unwrap();
 
-    let employee = employees.get(&id.into()).await?;
-    let employee: Option<Employee> = serde_wasm_bindgen::from_value(employee).unwrap();
-
-    Ok(employee)
+    Ok(employees
+        .get(&id.into())
+        .await?
+        .map(|value| serde_wasm_bindgen::from_value::<Employee>(value).unwrap()))
 }
 
 async fn get_all_employees(rexie: &Rexie, direction: Option<Direction>) -> Result<Vec<Employee>> {
@@ -228,8 +228,8 @@ async fn get_invoice(rexie: &Rexie, id: usize, year: u16) -> Result<Option<Invoi
 
     let invoice = invoices
         .get(&Array::of2(&JsValue::from_f64(id as _), &JsValue::from_f64(year as _)).into())
-        .await?;
-    let invoice: Option<Invoice> = serde_wasm_bindgen::from_value(invoice).unwrap();
+        .await?
+        .map(|value| serde_wasm_bindgen::from_value(value).unwrap());
 
     Ok(invoice)
 }


### PR DESCRIPTION
Hi!

* Added `getAllKeys` API support (on both transaction and store objects) - closes #24 
* Added `Store::key_exists` API
* **Breaking**: `get` now returns an `Option<T>` when the underlying `JsValue` is either `null` or `undefined`.
* Added a bit of docs here and there referencing the methods on MDN