### PR TITLE
Display idb::Error in Error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[non_exhaustive]
 pub enum Error {
     /// Indexed DB error
-    #[error("idb error")]
+    #[error("idb error: {0}")]
     IdbError(#[from] idb::Error),
     /// Couldn't abort a transaction
     #[error("couldn't abort a transaction")]


### PR DESCRIPTION
Under the current implementation, when a rexie::Error::IdbError is raised, very little information is given.

Consider the following (taken from inside my project with at least several layers of error types):

![image](https://github.com/user-attachments/assets/9e7b1b98-ce70-429d-8135-611027cea896)

Whilst everything seems very erroneous, _what_ the error is remains largely a mystery.

Now, with this patch, consider this:

![image](https://github.com/user-attachments/assets/48f6f9b0-4704-48a4-949e-08c42e16dad7)

I now have somewhere to base my debugging on.